### PR TITLE
PreciseJumpTarget not reset when ColorScheming

### DIFF
--- a/plugin/PreciseJump.vim
+++ b/plugin/PreciseJump.vim
@@ -24,7 +24,10 @@ if !exists('g:PreciseJump_target_keys')
 endif
 
 
-hi PreciseJumpTarget   ctermfg=yellow ctermbg=red cterm=bold gui=bold guibg=Red guifg=yellow
+"hi PreciseJumpTarget   ctermfg=yellow ctermbg=red cterm=bold gui=bold guibg=Red guifg=yellow
+if has("autocmd")
+  au ColorScheme * hi PreciseJumpTarget   ctermfg=yellow ctermbg=red cterm=bold gui=bold guibg=Red guifg=yellow
+endif
 
 if !exists('g:PreciseJump_match_target_hi')
     let g:PreciseJump_match_target_hi = 'PreciseJumpTarget'


### PR DESCRIPTION
- fix with an autocmd the fact that the Highlight "PreciseJumpTarget"
  will be reset if ColorScheme is callled somewhere in a sourced file after plugin load (ex: vimrc)
