### PR TITLE
Allow disabling default bindings.

### DIFF
--- a/plugin/PreciseJump.vim
+++ b/plugin/PreciseJump.vim
@@ -30,25 +30,27 @@ if !exists('g:PreciseJump_match_target_hi')
     let g:PreciseJump_match_target_hi = 'PreciseJumpTarget'
 endif
 
-nmap _F :call PreciseJumpF(0, 0, 0)<cr>
-vmap _F <ESC>:call PreciseJumpF(0, 0, 1)<cr>
-omap _F :call PreciseJumpF(0, 0, 0)<cr>
+if !exists('g:PreciseJump_disable_bindings')
+  nmap _F :call PreciseJumpF(0, 0, 0)<cr>
+  vmap _F <ESC>:call PreciseJumpF(0, 0, 1)<cr>
+  omap _F :call PreciseJumpF(0, 0, 0)<cr>
 
-nmap _f :call PreciseJumpF(-1, -1, 0)<cr>
-vmap _f <ESC>:call PreciseJumpF(-1, -1, 1)<cr>
-omap _f :call PreciseJumpF(-1, -1, 0)<cr>
+  nmap _f :call PreciseJumpF(-1, -1, 0)<cr>
+  vmap _f <ESC>:call PreciseJumpF(-1, -1, 1)<cr>
+  omap _f :call PreciseJumpF(-1, -1, 0)<cr>
 
-"nmap _t :call PreciseJumpT(-1, -1, 0)<cr>
-"vmap _t <ESC>:call PreciseJumpT(-1, -1, 1)<cr>
-"omap _t :call PreciseJumpT(-1, -1, 0)<cr>
-"
-"nmap _w :call PreciseJumpW(-1, -1, 0)<cr>
-"vmap _w <ESC>:call PreciseJumpW(-1, -1, 1)<cr>
-"omap _w :call PreciseJumpW(-1, -1, 0)<cr>
-"
-"nmap _e :call PreciseJumpE(-1, -1, 0)<cr>
-"vmap _e <ESC>:call PreciseJumpE(-1, -1, 1)<cr>
-"omap _e :call PreciseJumpE(-1, -1, 0)<cr>
+  "nmap _t :call PreciseJumpT(-1, -1, 0)<cr>
+  "vmap _t <ESC>:call PreciseJumpT(-1, -1, 1)<cr>
+  "omap _t :call PreciseJumpT(-1, -1, 0)<cr>
+  "
+  "nmap _w :call PreciseJumpW(-1, -1, 0)<cr>
+  "vmap _w <ESC>:call PreciseJumpW(-1, -1, 1)<cr>
+  "omap _w :call PreciseJumpW(-1, -1, 0)<cr>
+  "
+  "nmap _e :call PreciseJumpE(-1, -1, 0)<cr>
+  "vmap _e <ESC>:call PreciseJumpE(-1, -1, 1)<cr>
+  "omap _e :call PreciseJumpE(-1, -1, 0)<cr>
+end
 
 if exists('g:PreciseJump_I_am_brave')
     nmap F :call PreciseJumpF(0, 0, 0)<cr>

--- a/plugin/PreciseJump.vim
+++ b/plugin/PreciseJump.vim
@@ -90,6 +90,7 @@ function! PreciseJumpE(lines_prev, lines_next, vismode)
 endfunction
 
 function! PreciseJumpF(lines_prev, lines_next, vismode)
+    echo "destination>"
     let re = nr2char( getchar() )
     let re = escape(re, '.$^~')
     redraw


### PR DESCRIPTION
I realize this plugin isn't maintained and that furthermore this is just a mirror, but let's just consider this pull request a heads-up for others who might want the functionality in my fork.

I don't want the _ prefix since I use _ for other things, and unbinding
each of these default bindings was a hassle. An option to disable
default bindings allows the user to opt-in to bindings.

Example usage (with vundle)

``` vim
    " do the disabling
    let g:PreciseJump_disable_bindings = 1

    " load the plugin
    Bundle 'semanticart/PreciseJump'

    " set our own bindings
    nmap <C-f> :call PreciseJumpF(-1, -1, 0)<cr>
    vmap <C-f> <ESC>:call PreciseJumpF(-1, -1, 1)<cr>
    omap <C-f> :call PreciseJumpF(-1, -1, 0)<cr>
```
